### PR TITLE
Remove extraneous space from nfix dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/nanyuantingfeng/tomlifer.git"
   },
   "dependencies": {
-    "nfix ": "*",
+    "nfix": "*",
     "nclass": "*"
   },
   "author": "nanyuantingfeng",


### PR DESCRIPTION
Having the space meant that while npm would install nfix, it would always consider it extraneous.